### PR TITLE
Add license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
 	"name": "ff",
 	"version": "0.2.0",
 	"description": "Concise, Powerful Asynchronous Flow Control in JavaScript",
+	"license": "MIT",
 	"engine": [ "node >=0.2.0" ],
 	"author": "Marcus Cavanaugh <m@mcav.com>",
 	"contributors": [


### PR DESCRIPTION
This makes it easier for tools like https://www.npmjs.org/package/licensing to identify the licenses of dependencies and thus to ensure that your project only includes dependencies with a compatible license to its own.
