### PR TITLE
Improve testing

### DIFF
--- a/lib/ff.js
+++ b/lib/ff.js
@@ -36,8 +36,8 @@
 		setTimeout(next, 0);
 	};
 
-	function isPromise(maybePromise) {
-		return maybePromise && typeof maybePromise.then === "function";
+	function isPromise(p) {
+		return p && (typeof p === "object" || typeof p === "function") && typeof p.then === "function";
 	}
 
 	function copyToFunction (group, f) {
@@ -272,16 +272,22 @@
 	SuperGroup.prototype.success = SuperGroup.prototype.onSuccess;
 	SuperGroup.prototype.error = SuperGroup.prototype.onError;
 
-	SuperGroup.prototype.then = function (onSuccess, onError) {
+	SuperGroup.prototype.then = function (onFulfilled, onRejected) {
 		var defer = ff.defer();
+		
 		this.onSuccess(function () {
 			try {
-				if (typeof onSuccess !== "function") {
+				if (typeof onFulfilled !== "function") {
 					defer.apply(this, slice.call(arguments));
 				} else {
-					var value = onSuccess.apply(this, slice.call(arguments));
+					var value = onFulfilled.apply(undefined, slice.call(arguments));
+					
 					if (isPromise(value)) {
-						value.then(defer, defer.fail);
+						if (value === defer) {
+							throw new TypeError("promise and x refer to the same object");
+						} else {
+							value.then(defer, defer.fail);
+						}
 					} else {
 						defer(value);
 					}
@@ -290,14 +296,20 @@
 				defer.fail(e);
 			}
 		});
+		
 		this.onError(function () {
 			try {
-				if (typeof onError !== "function") {
+				if (typeof onRejected !== "function") {
 					defer.fail.apply(this, slice.call(arguments));
 				} else {
-					var value = onError.apply(this, slice.call(arguments));
+					var value = onRejected.apply(undefined, slice.call(arguments));
+					
 					if (isPromise(value)) {
-						value.then(defer, defer.fail);
+						if (value === defer) {
+							throw new TypeError("promise and x refer to the same object");
+						} else {
+							value.then(defer, defer.fail);
+						}
 					} else {
 						defer(value);
 					}
@@ -306,6 +318,7 @@
 				defer.fail(e);
 			}
 		});
+		
 		return defer;
 	}
 

--- a/package.json
+++ b/package.json
@@ -14,12 +14,12 @@
 	"main": "lib/ff",
 	"repository": "git://github.com/gameclosure/ff",
 	"scripts": {
-		"test": "mocha -R spec -t 5000 -s 1000 && promises-aplus-tests test/promise-adapter.js"
+		"test": "mocha -R spec && promises-aplus-tests test/promise-adapter.js"
 	},
 	"devDependencies": {
-		"chai": "1.8.0",
-		"mocha": "1.13.0",
-		"promises-aplus-tests": "1.3.2"
+		"chai": "~1.9.1",
+		"mocha": "~1.21.4",
+		"promises-aplus-tests": "~1.3.2"
 	},
 	"engines": {
 		"node": ">=0.6.0"

--- a/test/index.html
+++ b/test/index.html
@@ -1,24 +1,17 @@
+<!doctype html>
 <html>
-<head>
-  <meta charset="utf-8">
-  <title>Mocha Tests</title>
-  <link rel="stylesheet" href="../node_modules/mocha/mocha.css" />
-</head>
-<body>
-  <div id="mocha"></div>
-  <script src="../lib/ff.js"></script>
-  <script src="../node_modules/chai/chai.js"></script>
-  <script src="../node_modules/mocha/mocha.js"></script>
-  <script>
-    mocha.setup({
-      ui: 'bdd',
-      timeout: 5000
-    });
-    debugger;
-  </script>
-  <script src="./index.js"></script>  
-  <script>
-    mocha.run();
-  </script>
-</body>
+	<head>
+		<meta charset="utf-8">
+		<title>Mocha Tests</title>
+		<link rel="stylesheet" href="../node_modules/mocha/mocha.css">
+	</head>
+	<body>
+		<div id="mocha"></div>
+		<script src="../lib/ff.js"></script>
+		<script src="../node_modules/chai/chai.js"></script>
+		<script src="../node_modules/mocha/mocha.js"></script>
+		<script>mocha.setup("bdd")</script>
+		<script src="index.js"></script>
+		<script>mocha.run()</script>
+	</body>
 </html>

--- a/test/promise-adapter.js
+++ b/test/promise-adapter.js
@@ -1,28 +1,15 @@
-(function () {
-	if (typeof module !== "undefined") {
-		var ff = require("../lib/ff");
-	}
+var ff = require("../lib/ff");
 
-	var adapter = {
-		pending: function () {
-			var f = ff.defer();
-			return {
-				promise: f,
-				fulfill: function (value) {
-					f(value);
-				},
-				reject: function (reason) {
-					f.fail(reason);
-				}
-			}
+module.exports.pending = function () {
+	var f = ff.defer();
+
+	return {
+		promise: f,
+		fulfill: function (value) {
+			f(value);
+		},
+		reject: function (reason) {
+			f.fail(reason);
 		}
 	};
-
-	if (typeof module !== 'undefined') {
-		module.exports = adapter;
-	} else if (typeof exports !== 'undefined') {
-		exports = adapter; // jsio
-	} else {
-		this.adapter = adapter;
-	}
-}());
+};


### PR DESCRIPTION
- Specify chai, mocha, and promises-aplus-tests versions.
- Use mocha's default slow and timeout timing.
- Improve HTML.
- Fix the promises-aplus-tests wrapper.

All the main promise tests run again now. There's still some issues, but they were probably pre-existing.
